### PR TITLE
Fix executing current query/all queries in file

### DIFF
--- a/tql.el
+++ b/tql.el
@@ -91,14 +91,6 @@
 
 (defvar tiros-response-buffer-name "*Tiros Response*")
 
-(defvar tiros-root
-  ;; default to ..
-  (or (directory-file-name
-       (file-name-directory
-        (directory-file-name
-         (file-name-directory load-file-name)))) nil)
-  "Set this to the root directory of your tiros git checkout")
-
 (defvar tiros-endpoint 'dev "'dev | 'prod | 'local")
 (defvar tiros-flags "" "extra flags for tiros cli")
 


### PR DESCRIPTION
The elisp pulls out all defs in the file and prepends them when it
tries to dwim and run just the one query your cursor is currently on.
`C-c C-f` runs the whole file now, `C-c C-c` still does the
dwim-and-run-this-one-query. Improved error edge cases a little bit
too, if you happen to have the cursor positioned in a weird place (at
end of file, on a def) when you do `C-c C-c`.